### PR TITLE
Automatically install requirements (celery, statsd and six) via pip.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,10 @@ setup(
     author_email=about['__email__'],
 
     packages=find_packages(),
+    install_requires=[
+        "celery>=3.1.17",
+        "statsd>=3.0",
+        "six>=1.9.0",
+    ],
     zip_safe=False,
 )


### PR DESCRIPTION
This adds the celery, statsd and six packages to the setup.py so they are installed automatically if you `pip install celery-statsd`. I pulled the minimum versions from the `requirements.txt` file, but did not pin them since some of those packages (e.g. six) are used by many other packages.
