### PR TITLE
Fix CELERY_STATSD_PREFIX variable name in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ And in your settings file set `STATSD_HOST` and `STATSD_PORT`.
 
 You will now have stats about your tasks in statsd.
 
-By default stats will be published with a key prefix of "celery.". Change the CELERYD_STATS_PREFIX
+By default stats will be published with a key prefix of "celery.". Change the CELERY_STATSD_PREFIX
 if you want something different.


### PR DESCRIPTION
The ReadMe advises to edit the variable CELERYD_STATS_PREFIX,
but the code (`__init__.py#17`) looks for CELERY_STATSD_PREFIX.
